### PR TITLE
Correct custom build for brave 1.17

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = brave
 	pkgdesc = A web browser that stops ads and trackers by default
-	pkgver = 1.17.75
+	pkgver = 1.17.73
 	pkgrel = 1
 	url = https://www.brave.com/download
 	arch = x86_64
@@ -27,19 +27,19 @@ pkgbase = brave
 	optdepends = org.freedesktop.secrets: password storage backend on GNOME / Xfce
 	optdepends = kwallet: for storing passwords in KWallet on KDE desktops
 	optdepends = sccache: For faster builds
-	source = https://github.com/brave/brave-browser/archive/v1.17.75.tar.gz
+	source = https://github.com/brave/brave-browser/archive/v1.17.73.tar.gz
 	source = brave-launcher
 	source = brave-browser.desktop
 	source = chromium-launcher-6.tar.gz::https://github.com/foutrelis/chromium-launcher/archive/v6.tar.gz
 	source = https://github.com/stha09/chromium-patches/releases/download/chromium-87-patchset-9/chromium-87-patchset-9.tar.xz
 	source = brave-custom-build.patch
 	source = chromium-skia-harmony.patch::https://git.archlinux.org/svntogit/packages.git/plain/trunk/chromium-skia-harmony.patch?h=packages/chromium&id=63e8313d989fbb6f05b8886cefff67a643d3d888
-	sha256sums = 00fae544068fb94a82587ff7bbcba8430d0a1efd91ffcc5e84c06da6ce9b49fc
+	sha256sums = 090b705dab4e89f8b3ebc5abf879a1eb1b44ce0d29fa15b6a49cecdc1efe7888
 	sha256sums = 725e2d0c32da4b3de2c27a02abaf2f5acca7a25dcea563ae458c537ac4ffc4d5
 	sha256sums = fa6ed4341e5fc092703535b8becaa3743cb33c72f683ef450edd3ef66f70d42d
 	sha256sums = 04917e3cd4307d8e31bfb0027a5dce6d086edb10ff8a716024fbb8bb0c7dccf1
 	sha256sums = c99934bcd2f3ae8ea9620f5f59a94338b2cf739647f04c28c8a551d9083fa7e9
-	sha256sums = 8d1123e583e33ef8e91ddda0b62f7b8d51b9d6b61c73e74a90f40ef5f379573b
+	sha256sums = d492ca5946e8faba67be4893e89677c7053bdecafe06eed1df652bd37a948286
 	sha256sums = 771292942c0901092a402cc60ee883877a99fb804cb54d568c8c6c94565a48e1
 
 pkgname = brave

--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = brave
 	pkgdesc = A web browser that stops ads and trackers by default
-	pkgver = 1.17.73
+	pkgver = 1.17.75
 	pkgrel = 1
 	url = https://www.brave.com/download
 	arch = x86_64
@@ -27,19 +27,19 @@ pkgbase = brave
 	optdepends = org.freedesktop.secrets: password storage backend on GNOME / Xfce
 	optdepends = kwallet: for storing passwords in KWallet on KDE desktops
 	optdepends = sccache: For faster builds
-	source = https://github.com/brave/brave-browser/archive/v1.17.73.tar.gz
+	source = https://github.com/brave/brave-browser/archive/v1.17.75.tar.gz
 	source = brave-launcher
 	source = brave-browser.desktop
 	source = chromium-launcher-6.tar.gz::https://github.com/foutrelis/chromium-launcher/archive/v6.tar.gz
 	source = https://github.com/stha09/chromium-patches/releases/download/chromium-87-patchset-9/chromium-87-patchset-9.tar.xz
 	source = brave-custom-build.patch
 	source = chromium-skia-harmony.patch::https://git.archlinux.org/svntogit/packages.git/plain/trunk/chromium-skia-harmony.patch?h=packages/chromium&id=63e8313d989fbb6f05b8886cefff67a643d3d888
-	sha256sums = 090b705dab4e89f8b3ebc5abf879a1eb1b44ce0d29fa15b6a49cecdc1efe7888
+	sha256sums = 00fae544068fb94a82587ff7bbcba8430d0a1efd91ffcc5e84c06da6ce9b49fc
 	sha256sums = 725e2d0c32da4b3de2c27a02abaf2f5acca7a25dcea563ae458c537ac4ffc4d5
 	sha256sums = fa6ed4341e5fc092703535b8becaa3743cb33c72f683ef450edd3ef66f70d42d
 	sha256sums = 04917e3cd4307d8e31bfb0027a5dce6d086edb10ff8a716024fbb8bb0c7dccf1
 	sha256sums = c99934bcd2f3ae8ea9620f5f59a94338b2cf739647f04c28c8a551d9083fa7e9
-	sha256sums = d492ca5946e8faba67be4893e89677c7053bdecafe06eed1df652bd37a948286
+	sha256sums = 8d1123e583e33ef8e91ddda0b62f7b8d51b9d6b61c73e74a90f40ef5f379573b
 	sha256sums = 771292942c0901092a402cc60ee883877a99fb804cb54d568c8c6c94565a48e1
 
 pkgname = brave

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -27,8 +27,8 @@ fi
 ##
 
 pkgname=brave
-pkgver=1.17.73
-pkgrel=2
+pkgver=1.17.75
+pkgrel=1
 pkgdesc='A web browser that stops ads and trackers by default'
 arch=('x86_64')
 url='https://www.brave.com/download'
@@ -61,7 +61,7 @@ done
 # VAAPI patches from chromium-vaapi in AUR
 #source+=("vdpau-support.patch::https://aur.archlinux.org/cgit/aur.git/plain/vdpau-support.patch?h=chromium-vaapi&id=7c05464a8700b1a6144258320b2b33b352385f77")
 
-sha256sums=('090b705dab4e89f8b3ebc5abf879a1eb1b44ce0d29fa15b6a49cecdc1efe7888'
+sha256sums=('00fae544068fb94a82587ff7bbcba8430d0a1efd91ffcc5e84c06da6ce9b49fc'
             '725e2d0c32da4b3de2c27a02abaf2f5acca7a25dcea563ae458c537ac4ffc4d5'
             'fa6ed4341e5fc092703535b8becaa3743cb33c72f683ef450edd3ef66f70d42d'
             '04917e3cd4307d8e31bfb0027a5dce6d086edb10ff8a716024fbb8bb0c7dccf1'

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -28,7 +28,7 @@ fi
 
 pkgname=brave
 pkgver=1.17.73
-pkgrel=1
+pkgrel=2
 pkgdesc='A web browser that stops ads and trackers by default'
 arch=('x86_64')
 url='https://www.brave.com/download'
@@ -66,7 +66,7 @@ sha256sums=('090b705dab4e89f8b3ebc5abf879a1eb1b44ce0d29fa15b6a49cecdc1efe7888'
             'fa6ed4341e5fc092703535b8becaa3743cb33c72f683ef450edd3ef66f70d42d'
             '04917e3cd4307d8e31bfb0027a5dce6d086edb10ff8a716024fbb8bb0c7dccf1'
             'c99934bcd2f3ae8ea9620f5f59a94338b2cf739647f04c28c8a551d9083fa7e9'
-            'd492ca5946e8faba67be4893e89677c7053bdecafe06eed1df652bd37a948286'
+            '8d1123e583e33ef8e91ddda0b62f7b8d51b9d6b61c73e74a90f40ef5f379573b'
             '771292942c0901092a402cc60ee883877a99fb804cb54d568c8c6c94565a48e1')
 
 # Possible replacements are listed in build/linux/unbundle/replace_gn_files.py

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -27,8 +27,8 @@ fi
 ##
 
 pkgname=brave
-pkgver=1.17.75
-pkgrel=1
+pkgver=1.17.73
+pkgrel=2
 pkgdesc='A web browser that stops ads and trackers by default'
 arch=('x86_64')
 url='https://www.brave.com/download'
@@ -61,7 +61,7 @@ done
 # VAAPI patches from chromium-vaapi in AUR
 #source+=("vdpau-support.patch::https://aur.archlinux.org/cgit/aur.git/plain/vdpau-support.patch?h=chromium-vaapi&id=7c05464a8700b1a6144258320b2b33b352385f77")
 
-sha256sums=('00fae544068fb94a82587ff7bbcba8430d0a1efd91ffcc5e84c06da6ce9b49fc'
+sha256sums=('090b705dab4e89f8b3ebc5abf879a1eb1b44ce0d29fa15b6a49cecdc1efe7888'
             '725e2d0c32da4b3de2c27a02abaf2f5acca7a25dcea563ae458c537ac4ffc4d5'
             'fa6ed4341e5fc092703535b8becaa3743cb33c72f683ef450edd3ef66f70d42d'
             '04917e3cd4307d8e31bfb0027a5dce6d086edb10ff8a716024fbb8bb0c7dccf1'

--- a/brave-custom-build.patch
+++ b/brave-custom-build.patch
@@ -164,3 +164,16 @@ index d3bf012a5f..794ba63eb7 100644
  
  #include "base/logging.h"
  #include "brave/components/ipfs/common/ipfs_constants.h"
+diff --git a/brave/browser/brave_stats/brave_stats_updater.cc b/brave/browser/brave_stats/brave_stats_updater.cc
+index e4e9a0668f..20493aa078 100644
+--- a/brave/browser/brave_stats/brave_stats_updater.cc
++++ b/brave/browser/brave_stats/brave_stats_updater.cc
+@@ -171,9 +171,6 @@ void BraveStatsUpdater::SetStatsThresholdCallback(
+ 
+ GURL BraveStatsUpdater::BuildStatsEndpoint(const std::string& path) {
+   auto stats_updater_url = GURL(usage_server_ + path);
+-#if defined(OFFICIAL_BUILD)
+-  CHECK(stats_updater_url.is_valid());
+-#endif
+   return stats_updater_url;
+ }


### PR DESCRIPTION
After compiling brave with CFLAGS+=-g3 I found the browser crash on this code which I removed because our build is like developer build so it works (brave/brave-browser#12096)
btw. the debug binary is about 5 GB;)